### PR TITLE
feature#20/device-id-service feat: add DeviceIdService

### DIFF
--- a/src/Pulse.Tests/Pulse.Tests.csproj
+++ b/src/Pulse.Tests/Pulse.Tests.csproj
@@ -12,12 +12,14 @@
     <PackageReference Include="Aspire.Hosting.Testing" Version="13.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageReference Include="xunit.v3" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Pulse.WebApi\Pulse.WebApi.csproj" />
+    <ProjectReference Include="..\Pulse.WebApp\Pulse.WebApp.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pulse.Tests/WebApp/DeviceIdServiceTests.cs
+++ b/src/Pulse.Tests/WebApp/DeviceIdServiceTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.JSInterop;
+using Moq;
+using Pulse.WebApp.Services;
+using Xunit;
+
+namespace Pulse.Tests.WebApp;
+
+public class DeviceIdServiceTests
+{
+    private readonly Mock<IJSRuntime> _jsMock = new();
+    private readonly DeviceIdService _sut;
+
+    public DeviceIdServiceTests()
+    {
+        _sut = new DeviceIdService(_jsMock.Object);
+    }
+
+    [Fact]
+    public async Task GetDeviceIdAsync_NoExistingId_GeneratesAndStoresNewId()
+    {
+        _jsMock.Setup(js => js.InvokeAsync<string?>("localStorage.getItem",
+            It.IsAny<object[]>()))
+            .ReturnsAsync((string?)null);
+
+        _jsMock.Setup(js => js.InvokeAsync<Microsoft.JSInterop.Infrastructure.IJSVoidResult>("localStorage.setItem",
+            It.IsAny<object[]>()))
+            .ReturnsAsync(Mock.Of<Microsoft.JSInterop.Infrastructure.IJSVoidResult>());
+
+        var id = await _sut.GetDeviceIdAsync();
+
+        Assert.False(string.IsNullOrEmpty(id));
+        Assert.True(Guid.TryParse(id, out _), "ID should be a valid GUID");
+    }
+
+    [Fact]
+    public async Task GetDeviceIdAsync_ExistingId_ReturnsSameId()
+    {
+        var existingId = Guid.NewGuid().ToString();
+        _jsMock.Setup(js => js.InvokeAsync<string?>("localStorage.getItem",
+            It.IsAny<object[]>()))
+            .ReturnsAsync(existingId);
+
+        var id = await _sut.GetDeviceIdAsync();
+
+        Assert.Equal(existingId, id);
+    }
+
+    [Fact]
+    public async Task GetDeviceIdAsync_GeneratedId_IsValidGuidFormat()
+    {
+        _jsMock.Setup(js => js.InvokeAsync<string?>("localStorage.getItem",
+            It.IsAny<object[]>()))
+            .ReturnsAsync((string?)null);
+
+        _jsMock.Setup(js => js.InvokeAsync<Microsoft.JSInterop.Infrastructure.IJSVoidResult>("localStorage.setItem",
+            It.IsAny<object[]>()))
+            .ReturnsAsync(Mock.Of<Microsoft.JSInterop.Infrastructure.IJSVoidResult>());
+
+        var id = await _sut.GetDeviceIdAsync();
+
+        Assert.Matches(@"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", id);
+    }
+}

--- a/src/Pulse.WebApp/Services/DeviceIdService.cs
+++ b/src/Pulse.WebApp/Services/DeviceIdService.cs
@@ -1,0 +1,30 @@
+using Microsoft.JSInterop;
+
+namespace Pulse.WebApp.Services;
+
+public interface IDeviceIdService
+{
+    Task<string> GetDeviceIdAsync();
+}
+
+public class DeviceIdService : IDeviceIdService
+{
+    private readonly IJSRuntime _js;
+    private const string Key = "pulse_device_id";
+
+    public DeviceIdService(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    public async Task<string> GetDeviceIdAsync()
+    {
+        var id = await _js.InvokeAsync<string?>("localStorage.getItem", Key);
+        if (string.IsNullOrEmpty(id))
+        {
+            id = Guid.NewGuid().ToString();
+            await _js.InvokeVoidAsync("localStorage.setItem", Key, id);
+        }
+        return id;
+    }
+}


### PR DESCRIPTION
# Pull Request

C# Blazor service that generates a UUID on first visit and stores it in localStorage via JS interop; exposes `GetDeviceIdAsync()`.

- Added `IDeviceIdService` interface and `DeviceIdService` implementation in `Pulse.WebApp/Services/`.
- Implemented `GetDeviceIdAsync()` using `IJSRuntime` to read and write localStorage.
- Generates a new `Guid` when no ID exists and persists it under key `pulse_device_id`.
- Registered `IDeviceIdService` as scoped in `Program.cs`.
- Added project reference from `Pulse.Tests` to `Pulse.WebApp`.
- Added unit tests covering first-visit generation, repeat-visit persistence, and GUID format validation.

## Related Issues
Closes #20 

<img width="606" height="314" alt="Screenshot 2026-03-20 at 10 26 34 AM" src="https://github.com/user-attachments/assets/c88c8b22-f45e-4548-ab3c-6819093d1195" />

<img width="611" height="281" alt="Screenshot 2026-03-20 at 10 29 24 AM" src="https://github.com/user-attachments/assets/aa9d4cfb-9c16-4a38-9cd3-5b97883e056f" />


## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes