### PR TITLE
28 instructor session list api GET /sessions (InstructorCode header)

### DIFF
--- a/docs/pbi-implementations/13-implement-question-model-class.md
+++ b/docs/pbi-implementations/13-implement-question-model-class.md
@@ -1,0 +1,92 @@
+## PBI: Implement Question model class
+
+### Summary
+Create a new `Question` domain entity for Pulse 2.0 to support classroom pulse questions tied to class sessions. This model will represent the core structure for questions sent by faculty during live sessions and reused later.
+
+### Work to be completed
+- Add a new `Question` entity in `src/Pulse.Domain/Entities/Question.cs` (or the equivalent domain/entities folder).
+- Include the following fields with appropriate types based on existing project conventions:
+  - `Id`
+  - `SessionId`
+  - `Text`
+  - `Type`
+  - `Options`
+  - `SortOrder`
+  - `CreatedAt`
+- Ensure `Text` is required.
+- Ensure `Type` supports the expected question formats such as multiple choice, Likert-scale, and open-ended.
+- Ensure `Options` supports storing multiple answer choices when applicable.
+- Set `CreatedAt` with a sensible default value of `DateTime.UtcNow`.
+- Update the EF Core `DbContext` to include a `DbSet<Question>` if the project uses Entity Framework.
+- Apply any needed entity configuration, validation, annotations, or fluent API mappings so the entity aligns with database and domain rules.
+- Verify the solution builds successfully.
+- Add unit tests to confirm:
+  - the model can be instantiated,
+  - all properties can be assigned correctly,
+  - default values behave as expected,
+  - and no regressions are introduced by the new entity.
+
+### Expected outcome
+A fully implemented `Question` model exists in the domain layer, compiles successfully, is wired into persistence if applicable, and is covered by unit tests to validate structure and behavior.
+
+
+## Definition of Done
+
+### Functional
+- A `Question` entity class exists in the correct domain location.
+- The entity includes all required fields:
+  - `Id`
+  - `SessionId`
+  - `Text`
+  - `Type`
+  - `Options`
+  - `SortOrder`
+  - `CreatedAt`
+- All properties use the correct types based on project conventions.
+- `Text` is required.
+- `CreatedAt` is initialized with an appropriate default value.
+- `Options` supports multiple values for question types that require selectable answers.
+- `Question` is added to the `DbContext` as a `DbSet<Question>` if EF Core is used.
+
+### Quality
+- The implementation follows project naming conventions, folder structure, and coding standards.
+- Any validation, annotations, or fluent configuration required by the project are included.
+- The solution compiles without warnings or errors related to the new model.
+- The implementation does not break existing domain, persistence, or test behavior.
+
+### Verification
+- `dotnet build` completes successfully for the solution.
+- Unit tests are added and passing.
+- Unit Tests must verify the implementation is working successfully without breaking other parts of the software.
+- Tests validate:
+  - entity instantiation,
+  - property assignment,
+  - required field expectations,
+  - collection handling for `Options`,
+  - default value behavior for `CreatedAt`.
+- If migrations are part of the workflow, the generated migration correctly adds the `Question` table/columns.
+
+### Verification Commands (API + Tests)
+- Start the API:
+  - `dotnet run --project src/Pulse.WebApi/Pulse.WebApi.csproj`
+- Browser/manual endpoint checks:
+  - `http://localhost:5062/` (expected: `Pulse API is running`)
+  - `http://localhost:5062/questions` (expected: JSON array, often `[]` initially)
+  - `http://localhost:5062/health` (development health endpoint)
+  - `http://localhost:5062/alive` (development liveness endpoint)
+- CLI endpoint checks:
+  - `curl http://localhost:5062/questions`
+  - `curl -X POST "http://localhost:5062/questions" -H "Content-Type: application/json" -d '{"sessionId":"11111111-1111-1111-1111-111111111111","text":"Is this live?","type":0,"options":[],"sortOrder":1}'`
+- Unit tests:
+  - `dotnet test src/Pulse.Tests/Pulse.Tests.csproj`
+- Optional: run all tests in the repo:
+  - `dotnet test`
+
+### Documentation / PR Evidence
+- PR includes the new `Question` entity.
+- PR includes any `DbContext` or EF configuration updates.
+- PR includes unit tests for the new entity.
+- PR description or checklist includes evidence of:
+  - successful build,
+  - passing tests,
+  - and migration output if applicable.

--- a/docs/pbi-implementations/22-put-apiquestionsid-update-question.md
+++ b/docs/pbi-implementations/22-put-apiquestionsid-update-question.md
@@ -1,0 +1,80 @@
+## PBI: 22-put-apiquestionsid-update-question
+
+### Description
+Endpoint to update a question's text, type, and options; validates input.
+
+### Acceptance Criteria
+- Returns 200 and updated question on valid update.
+- Returns 400 on invalid payload (e.g., MC with <2 options).
+
+### Implementation checklist
+- Add/confirm request DTO for update payload (text, type, options).
+- Add endpoint handler for `PUT /api/questions/{id}` in Web API.
+- Validate input:
+	- id is valid.
+	- Required fields are present.
+	- MC questions have at least 2 options.
+- Lookup existing question by id; return 404 when not found.
+- Apply updates and persist changes.
+- Return 200 with updated question model.
+- Add/confirm unit tests for valid update and invalid payload.
+
+## Definition of Done
+
+### Checklist
+- Endpoint implemented and reachable.
+- Returns 200 + updated question for valid payload.
+- Returns 400 for invalid payload (including MC < 2 options).
+- Returns 404 for unknown question id.
+- Automated tests added/updated and passing.
+- `dotnet build` succeeds.
+
+### Manual Verification (API)
+- Start the API:
+	- `dotnet run --project src/Pulse.WebApi/Pulse.WebApi.csproj`
+- Verify service health in browser:
+	- `http://localhost:5062/` (expected: `Pulse API is running`)
+	- `http://localhost:5062/questions` (expected: JSON array)
+
+### Manual Verification (cURL)
+Use these commands exactly as written. Do not escape option flags like `-H` or `-d`.
+
+1. Create a seed question and capture its `id`.
+
+```bash
+curl -i -sS -X POST "http://localhost:5062/questions" -H "Content-Type: application/json" -d '{"sessionId":"11111111-1111-1111-1111-111111111111","text":"Original question?","type":2,"options":[],"sortOrder":1}'
+```
+
+Optional: save the returned `id` for reuse.
+
+```bash
+QUESTION_ID=$(curl -sS -X POST "http://localhost:5062/questions" -H "Content-Type: application/json" -d '{"sessionId":"11111111-1111-1111-1111-111111111112","text":"Original question?","type":2,"options":[],"sortOrder":1}' | jq -r '.id')
+echo "$QUESTION_ID"
+```
+
+2. Update the question with a valid payload (expect HTTP 200 + updated model).
+
+```bash
+curl -i -sS -X PUT "http://localhost:5062/api/questions/<QUESTION_ID>" -H "Content-Type: application/json" -d '{"text":"Updated question text","type":0,"options":["Option A","Option B"]}'
+```
+
+3. Validate invalid MC payload (expect HTTP 400).
+
+```bash
+curl -i -sS -X PUT "http://localhost:5062/api/questions/<QUESTION_ID>" -H "Content-Type: application/json" -d '{"text":"Invalid MC payload","type":0,"options":["Only one option"]}'
+```
+
+4. Validate unknown id behavior (expect HTTP 404).
+
+```bash
+curl -i -sS -X PUT "http://localhost:5062/api/questions/00000000-0000-0000-0000-000000000123" -H "Content-Type: application/json" -d '{"text":"Question not found","type":2,"options":[]}'
+```
+
+### Automated Verification
+- Run targeted tests for this PBI:
+	- `dotnet test src/Pulse.Tests/Pulse.Tests.csproj --filter QuestionUpdateEndpointTests`
+- Run all tests:
+	- `dotnet test`
+- Build impacted projects:
+	- `dotnet build src/Pulse.WebApi/Pulse.WebApi.csproj`
+	- `dotnet build src/Pulse.Tests/Pulse.Tests.csproj`

--- a/docs/pbi-implementations/28-instructor-session-list-api-get-apisessionsinstructorcode.md
+++ b/docs/pbi-implementations/28-instructor-session-list-api-get-apisessionsinstructorcode.md
@@ -1,0 +1,29 @@
+## PBI: Instructor session list API - GET /api/sessions?instructorCode=... #28
+
+### Description
+Endpoint that returns all sessions belonging to the instructor identified by their `InstructorCode`.
+
+### Acceptance Criteria
+- [ ] Returns 200 and an array of sessions when the `InstructorCode` is valid.
+- [ ] Returns 401/403 when the `InstructorCode` is missing or invalid.
+
+### Implementation checklist
+- [ ] Add/confirm endpoint handler for `GET /api/sessions` (or equivalent) in Web API.
+- [ ] Extract and validate the `InstructorCode` from the request (e.g. header or query parameter).
+- [ ] Return 401 when `InstructorCode` is missing.
+- [ ] Return 403 when `InstructorCode` is present but invalid/unrecognised.
+- [ ] Lookup all sessions associated with the valid `InstructorCode` from the repository.
+- [ ] Return 200 with the array of session models on success.
+- [ ] Return an empty array (not 404) if the instructor has no sessions.
+- [ ] Add/confirm unit tests for valid code, missing code, and invalid code scenarios.
+
+## Definition of Done
+
+### PBI Checklist
+- [ ] Endpoint implemented and reachable.
+- [ ] Returns 200 + array of sessions for a valid `InstructorCode`.
+- [ ] Returns 401 for a missing `InstructorCode`.
+- [ ] Returns 403 for an invalid/unrecognised `InstructorCode`.
+- [ ] Automated tests added/updated and passing.
+- [ ] `dotnet build` succeeds.
+- [ ] Linting passes (`dotnet format --verify-no-changes`).

--- a/docs/pbi-implementations/28-instructor-session-list-api-get-apisessionsinstructorcode.md
+++ b/docs/pbi-implementations/28-instructor-session-list-api-get-apisessionsinstructorcode.md
@@ -27,3 +27,47 @@ Endpoint that returns all sessions belonging to the instructor identified by the
 - [ ] Automated tests added/updated and passing.
 - [ ] `dotnet build` succeeds.
 - [ ] Linting passes (`dotnet format --verify-no-changes`).
+
+### Manual Verification (API)
+- Configure instructor code before starting the API (required for valid-code success path):
+	- Temporary (current shell): `export Security__InstructorCode=INST001`
+	- or set `"Security": { "InstructorCode": "INST001" }` in `src/Pulse.WebApi/appsettings.Development.json`
+- Start the API:
+	- `dotnet run --project src/Pulse.WebApi/Pulse.WebApi.csproj`
+- Verify service health in browser:
+	- `http://localhost:5062/` (expected: `Pulse API is running`)
+
+### Manual Verification (cURL)
+1. Valid `InstructorCode` should return HTTP 200 with an array (possibly empty).
+
+```bash
+curl -i -sS "http://localhost:5062/sessions" -H "InstructorCode: INST001"
+```
+
+2. Missing `InstructorCode` should return HTTP 401 with JSON error.
+
+```bash
+curl -i -sS "http://localhost:5062/sessions"
+```
+
+3. Invalid `InstructorCode` should return HTTP 403 with JSON error.
+
+```bash
+curl -i -sS "http://localhost:5062/sessions" -H "InstructorCode: WRONG"
+```
+
+### Automated Verification
+- Run targeted unit tests for this endpoint behavior:
+	- `dotnet test src/Pulse.Tests/Pulse.Tests.csproj --filter GetSessionsByInstructorCodeEndpointTests`
+- Run all tests:
+	- `dotnet test src/Pulse.Tests/Pulse.Tests.csproj`
+- Build solution:
+	- `dotnet build Pulse.slnx`
+- Verify formatting:
+	- `dotnet format Pulse.slnx --verify-no-changes`
+
+### Unit Test Location
+- `src/Pulse.Tests/Sessions/CreateSessionTests.cs`
+  - `GetSessionsByInstructorCodeEndpointTests.GetSessionsValidInstructorCodeReturns200AndArray`
+  - `GetSessionsByInstructorCodeEndpointTests.GetSessionsMissingInstructorCodeReturns401`
+  - `GetSessionsByInstructorCodeEndpointTests.GetSessionsInvalidInstructorCodeReturns403`

--- a/docs/pbi-implementations/28-instructor-session-list-api-get-apisessionsinstructorcode.md
+++ b/docs/pbi-implementations/28-instructor-session-list-api-get-apisessionsinstructorcode.md
@@ -1,37 +1,39 @@
-## PBI: Instructor session list API - GET /api/sessions?instructorCode=... #28
+## PBI: Instructor session list API - GET /sessions #28
 
 ### Description
 Endpoint that returns all sessions belonging to the instructor identified by their `InstructorCode`.
 
+The `InstructorCode` is passed as an HTTP request header (not a query parameter). Access control is enforced by `InstructorCodeMiddleware` before the endpoint handler is reached.
+
 ### Acceptance Criteria
-- [ ] Returns 200 and an array of sessions when the `InstructorCode` is valid.
-- [ ] Returns 401/403 when the `InstructorCode` is missing or invalid.
+- [x] Returns 200 and an array of sessions when the `InstructorCode` is valid.
+- [x] Returns 401/403 when the `InstructorCode` is missing or invalid.
 
 ### Implementation checklist
-- [ ] Add/confirm endpoint handler for `GET /api/sessions` (or equivalent) in Web API.
-- [ ] Extract and validate the `InstructorCode` from the request (e.g. header or query parameter).
-- [ ] Return 401 when `InstructorCode` is missing.
-- [ ] Return 403 when `InstructorCode` is present but invalid/unrecognised.
-- [ ] Lookup all sessions associated with the valid `InstructorCode` from the repository.
-- [ ] Return 200 with the array of session models on success.
-- [ ] Return an empty array (not 404) if the instructor has no sessions.
-- [ ] Add/confirm unit tests for valid code, missing code, and invalid code scenarios.
+- [x] Add/confirm endpoint handler for `GET /sessions` in Web API.
+- [x] Extract and validate the `InstructorCode` from the `InstructorCode` request header via `InstructorCodeMiddleware`.
+- [x] Return 401 when `InstructorCode` is missing.
+- [x] Return 403 when `InstructorCode` is present but invalid/unrecognised.
+- [x] Lookup all sessions associated with the valid `InstructorCode` from the repository.
+- [x] Return 200 with the array of session models on success.
+- [x] Return an empty array (not 404) if the instructor has no sessions.
+- [x] Add/confirm unit tests for valid code and no-match scenarios.
 
 ## Definition of Done
 
 ### PBI Checklist
-- [ ] Endpoint implemented and reachable.
-- [ ] Returns 200 + array of sessions for a valid `InstructorCode`.
-- [ ] Returns 401 for a missing `InstructorCode`.
-- [ ] Returns 403 for an invalid/unrecognised `InstructorCode`.
-- [ ] Automated tests added/updated and passing.
-- [ ] `dotnet build` succeeds.
-- [ ] Linting passes (`dotnet format --verify-no-changes`).
+- [x] Endpoint implemented and reachable.
+- [x] Returns 200 + array of sessions for a valid `InstructorCode`.
+- [x] Returns 401 for a missing `InstructorCode`.
+- [x] Returns 403 for an invalid/unrecognised `InstructorCode`.
+- [x] Automated tests added/updated and passing.
+- [x] `dotnet build` succeeds.
+- [x] Linting passes (`dotnet format --verify-no-changes`).
 
 ### Manual Verification (API)
 - Configure instructor code before starting the API (required for valid-code success path):
-	- Temporary (current shell): `export Security__InstructorCode=INST001`
-	- or set `"Security": { "InstructorCode": "INST001" }` in `src/Pulse.WebApi/appsettings.Development.json`
+	- Recommended: `export Security__InstructorCode=INST001` (environment variable, not committed to source)
+	- Do **not** commit `InstructorCode` values to `appsettings.Development.json`; use environment variables or user-secrets instead.
 - Start the API:
 	- `dotnet run --project src/Pulse.WebApi/Pulse.WebApi.csproj`
 - Verify service health in browser:
@@ -69,5 +71,5 @@ curl -i -sS "http://localhost:5062/sessions" -H "InstructorCode: WRONG"
 ### Unit Test Location
 - `src/Pulse.Tests/Sessions/CreateSessionTests.cs`
   - `GetSessionsByInstructorCodeEndpointTests.GetSessionsValidInstructorCodeReturns200AndArray`
-  - `GetSessionsByInstructorCodeEndpointTests.GetSessionsMissingInstructorCodeReturns401`
-  - `GetSessionsByInstructorCodeEndpointTests.GetSessionsInvalidInstructorCodeReturns403`
+  - `GetSessionsByInstructorCodeEndpointTests.GetSessionsNoMatchingCodeReturnsEmptyArray`
+- `src/Pulse.Tests/InstructorCodeMiddlewareTests.cs` — covers 401/403 enforcement

--- a/docs/pbi-implementations/39-apply-instructorcode-middleware-to-questionsession-management-endpoints.md
+++ b/docs/pbi-implementations/39-apply-instructorcode-middleware-to-questionsession-management-endpoints.md
@@ -1,0 +1,38 @@
+## PBI: 39-apply-instructorcode-middleware-to-questionsession-management-endpoints
+
+### Description
+Ensure middleware is applied to all instructor-only APIs.
+
+### Acceptance Criteria
+- [ ] Missing InstructorCode returns 401; invalid returns 403.
+
+### Implementation checklist
+- [ ] Identify instructor-only routes (question/session management + results + QR as applicable).
+- [ ] Apply middleware to all identified routes.
+- [ ] Ensure middleware reads `InstructorCode` consistently from expected header/source.
+- [ ] Verify behavior:
+	- [ ] Missing code -> 401.
+	- [ ] Invalid code -> 403.
+	- [ ] Valid code -> request continues.
+- [ ] Add/confirm tests for 401, 403, and success path.
+- [ ] Ensure no student/public endpoints are accidentally protected.
+
+## Definition of Done
+
+### PBI Checklist
+- [ ] Middleware is wired to all intended instructor-only endpoints.
+- [ ] Missing `InstructorCode` returns 401.
+- [ ] Invalid `InstructorCode` returns 403.
+- [ ] Valid `InstructorCode` allows endpoint execution.
+- [ ] Public/student endpoints remain accessible as designed.
+- [ ] Automated tests added/updated and passing.
+- [ ] `dotnet build` and `dotnet test` succeed.
+
+### Automated Verification
+- Run targeted middleware tests (or equivalent endpoint-level tests):
+	- `dotnet test src/Pulse.Tests/Pulse.Tests.csproj --filter InstructorCode`
+- Run all tests:
+	- `dotnet test`
+- Build impacted projects:
+	- `dotnet build src/Pulse.WebApi/Pulse.WebApi.csproj`
+	- `dotnet build src/Pulse.Tests/Pulse.Tests.csproj`

--- a/src/Pulse.Shared/Services/ISessionRepository.cs
+++ b/src/Pulse.Shared/Services/ISessionRepository.cs
@@ -18,5 +18,10 @@ public interface ISessionRepository
     /// <returns>A unique 6-character join code</returns>
     Task<string> GenerateUniqueJoinCodeAsync();
 
+    /// <summary>
+    /// Returns all sessions owned by the given instructor code.
+    /// </summary>
+    Task<IEnumerable<Session>> GetByInstructorCodeAsync(string instructorCode);
+
     Task<bool> JoinCodeExistsAsync(string joinCode, CancellationToken ct = default);
 }

--- a/src/Pulse.Shared/Services/QuestionRepository.cs
+++ b/src/Pulse.Shared/Services/QuestionRepository.cs
@@ -16,4 +16,5 @@ public class QuestionRepository
     public Question Insert(Question q) { _col.Insert(q); return q; }
     public Question? GetById(Guid id) => _col.FindById(id);
     public bool Update(Question q) => _col.Update(q);
+    public bool Delete(Guid id) => _col.Delete(id);
 }

--- a/src/Pulse.Shared/Services/SessionRepository.cs
+++ b/src/Pulse.Shared/Services/SessionRepository.cs
@@ -39,6 +39,16 @@ public class SessionRepository : ISessionRepository
         return await Task.FromResult(code);
     }
 
+    public Task<IEnumerable<Session>> GetByInstructorCodeAsync(string instructorCode)
+    {
+        if (string.IsNullOrWhiteSpace(instructorCode))
+            return Task.FromResult(Enumerable.Empty<Session>());
+
+        var collection = _db.GetCollection<Session>(SessionCollectionName);
+        var sessions = collection.Find(s => s.InstructorCode == instructorCode).ToList();
+        return Task.FromResult<IEnumerable<Session>>(sessions);
+    }
+
     public Task<bool> JoinCodeExistsAsync(string joinCode, CancellationToken ct = default)
     {
         var collection = _db.GetCollection(SessionCollectionName);

--- a/src/Pulse.Tests/GlobalExceptionMiddlewareTests.cs
+++ b/src/Pulse.Tests/GlobalExceptionMiddlewareTests.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Aspire.Hosting.Testing;
+using LiteDB;
+using Pulse.Common.Services;
+using Pulse.Shared.Models;
+using Pulse.WebApi;
+using Pulse.WebApi.Middleware;
 using Xunit;
 
 namespace Pulse.Tests;
@@ -90,5 +96,99 @@ public class GlobalExceptionMiddlewareTests
         Assert.Equal(correlationId, scope["CorrelationId"]?.ToString());
         Assert.Equal("/test/path", scope["RequestPath"]?.ToString());
         Assert.Equal("POST", scope["RequestMethod"]?.ToString());
+    }
+}
+
+public class GetSessionsByInstructorCodeEndpointTests
+{
+    [Fact]
+    public async Task GetSessionsValidInstructorCodeReturns200AndArray()
+    {
+        using var db = new LiteDatabase("Filename=:memory:");
+        var collection = db.GetCollection<Session>("sessions");
+        collection.Insert(new Session
+        {
+            Id = Guid.NewGuid(),
+            Title = "Session A",
+            InstructorCode = "INST001",
+            JoinCode = "ABC123",
+            Status = "Active",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        collection.Insert(new Session
+        {
+            Id = Guid.NewGuid(),
+            Title = "Session B",
+            InstructorCode = "OTHER",
+            JoinCode = "ZZZ999",
+            Status = "Active",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        var repo = new SessionRepository(db);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "INST001";
+
+        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
+
+        Assert.Equal(StatusCodes.Status200OK, statusResult.StatusCode);
+
+        var sessions = Assert.IsAssignableFrom<IEnumerable<Session>>(valueResult.Value);
+        var list = sessions.ToList();
+
+        Assert.Single(list);
+        Assert.True(list[0].InstructorCode == "INST001");
+    }
+
+    [Fact]
+    public async Task GetSessionsMissingInstructorCodeReturns401()
+    {
+        using var db = new LiteDatabase("Filename=:memory:");
+        var repo = new SessionRepository(db);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var context = new DefaultHttpContext();
+
+        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, statusResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetSessionsInvalidInstructorCodeReturns403()
+    {
+        using var db = new LiteDatabase("Filename=:memory:");
+        var repo = new SessionRepository(db);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "WRONG";
+
+        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, statusResult.StatusCode);
     }
 }

--- a/src/Pulse.Tests/GlobalExceptionMiddlewareTests.cs
+++ b/src/Pulse.Tests/GlobalExceptionMiddlewareTests.cs
@@ -5,14 +5,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Aspire.Hosting.Testing;
-using LiteDB;
-using Pulse.Common.Services;
-using Pulse.Shared.Models;
-using Pulse.WebApi;
-using Pulse.WebApi.Middleware;
 using Xunit;
 
 namespace Pulse.Tests;
@@ -96,99 +89,5 @@ public class GlobalExceptionMiddlewareTests
         Assert.Equal(correlationId, scope["CorrelationId"]?.ToString());
         Assert.Equal("/test/path", scope["RequestPath"]?.ToString());
         Assert.Equal("POST", scope["RequestMethod"]?.ToString());
-    }
-}
-
-public class GetSessionsByInstructorCodeEndpointTests
-{
-    [Fact]
-    public async Task GetSessionsValidInstructorCodeReturns200AndArray()
-    {
-        using var db = new LiteDatabase("Filename=:memory:");
-        var collection = db.GetCollection<Session>("sessions");
-        collection.Insert(new Session
-        {
-            Id = Guid.NewGuid(),
-            Title = "Session A",
-            InstructorCode = "INST001",
-            JoinCode = "ABC123",
-            Status = "Active",
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
-        });
-        collection.Insert(new Session
-        {
-            Id = Guid.NewGuid(),
-            Title = "Session B",
-            InstructorCode = "OTHER",
-            JoinCode = "ZZZ999",
-            Status = "Active",
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
-        });
-
-        var repo = new SessionRepository(db);
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Security:InstructorCode"] = "INST001"
-            })
-            .Build();
-
-        var context = new DefaultHttpContext();
-        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "INST001";
-
-        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
-        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-        var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
-
-        Assert.Equal(StatusCodes.Status200OK, statusResult.StatusCode);
-
-        var sessions = Assert.IsAssignableFrom<IEnumerable<Session>>(valueResult.Value);
-        var list = sessions.ToList();
-
-        Assert.Single(list);
-        Assert.True(list[0].InstructorCode == "INST001");
-    }
-
-    [Fact]
-    public async Task GetSessionsMissingInstructorCodeReturns401()
-    {
-        using var db = new LiteDatabase("Filename=:memory:");
-        var repo = new SessionRepository(db);
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Security:InstructorCode"] = "INST001"
-            })
-            .Build();
-
-        var context = new DefaultHttpContext();
-
-        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
-        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-
-        Assert.Equal(StatusCodes.Status401Unauthorized, statusResult.StatusCode);
-    }
-
-    [Fact]
-    public async Task GetSessionsInvalidInstructorCodeReturns403()
-    {
-        using var db = new LiteDatabase("Filename=:memory:");
-        var repo = new SessionRepository(db);
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Security:InstructorCode"] = "INST001"
-            })
-            .Build();
-
-        var context = new DefaultHttpContext();
-        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "WRONG";
-
-        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
-        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-
-        Assert.Equal(StatusCodes.Status403Forbidden, statusResult.StatusCode);
     }
 }

--- a/src/Pulse.Tests/InstructorCodeMiddlewareTests.cs
+++ b/src/Pulse.Tests/InstructorCodeMiddlewareTests.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Pulse.WebApi.Middleware;
+
+namespace Pulse.Tests;
+
+public class InstructorCodeMiddlewareTests
+{
+    [Fact]
+    public async Task DeleteQuestionMissingInstructorCodeReturns401()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var nextCalled = false;
+        RequestDelegate next = _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new InstructorCodeMiddleware(next, configuration);
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Delete;
+        context.Request.Path = "/questions/00000000-0000-0000-0000-000000000001";
+        context.Response.Body = new MemoryStream();
+
+        await middleware.Invoke(context);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+        Assert.False(nextCalled);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+        var body = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("InstructorCode is required.", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void IsInstructorOnlyReturnsTrueForProtectedSessionRoute()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Path = "/sessions/abc123/results";
+
+        var isProtected = InstructorOnlyEndpointMatcher.IsInstructorOnly(context.Request);
+
+        Assert.True(isProtected);
+    }
+
+    [Fact]
+    public void IsInstructorOnlyReturnsFalseForPublicStudentRoute()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Post;
+        context.Request.Path = "/sessions/abc123/join";
+
+        var isProtected = InstructorOnlyEndpointMatcher.IsInstructorOnly(context.Request);
+
+        Assert.False(isProtected);
+    }
+}

--- a/src/Pulse.Tests/InstructorCodeMiddlewareTests.cs
+++ b/src/Pulse.Tests/InstructorCodeMiddlewareTests.cs
@@ -44,6 +44,77 @@ public class InstructorCodeMiddlewareTests
     }
 
     [Fact]
+    public async Task GetSessionsMissingInstructorCodeReturns401()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var nextCalled = false;
+        RequestDelegate next = _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new InstructorCodeMiddleware(next, configuration);
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Path = "/sessions";
+        context.Response.Body = new MemoryStream();
+
+        await middleware.Invoke(context);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+        Assert.False(nextCalled);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+        var body = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("InstructorCode is required.", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task GetSessionsInvalidInstructorCodeReturns403()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var nextCalled = false;
+        RequestDelegate next = _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new InstructorCodeMiddleware(next, configuration);
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Path = "/sessions";
+        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "WRONG";
+        context.Response.Body = new MemoryStream();
+
+        await middleware.Invoke(context);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+        Assert.False(nextCalled);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+        var body = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("InstructorCode is invalid.", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [Fact]
     public void IsInstructorOnlyReturnsTrueForProtectedSessionRoute()
     {
         var context = new DefaultHttpContext();

--- a/src/Pulse.Tests/QuestionUpdateEndpointTests.cs
+++ b/src/Pulse.Tests/QuestionUpdateEndpointTests.cs
@@ -110,4 +110,35 @@ public class QuestionUpdateEndpointTests
         var badRequest = Assert.IsType<BadRequest<string>>(result.Result);
         Assert.Equal("Question id is invalid.", badRequest.Value);
     }
+
+    [Fact]
+    public void DeleteQuestionReturnsNoContentWhenQuestionExists()
+    {
+        using var db = new LiteDB.LiteDatabase("Filename=:memory:");
+        var repo = new QuestionRepository(db);
+
+        var existing = new Question
+        {
+            Id = Guid.NewGuid(),
+            Text = "Delete me",
+            Type = QuestionType.OpenEnded,
+            Options = new List<string>()
+        };
+        repo.Insert(existing);
+
+        var result = QuestionEndpointHandlers.DeleteQuestion(existing.Id, repo);
+
+        Assert.IsType<NoContent>(result.Result);
+    }
+
+    [Fact]
+    public void DeleteQuestionReturnsNotFoundWhenQuestionDoesNotExist()
+    {
+        using var db = new LiteDB.LiteDatabase("Filename=:memory:");
+        var repo = new QuestionRepository(db);
+
+        var result = QuestionEndpointHandlers.DeleteQuestion(Guid.NewGuid(), repo);
+
+        Assert.IsType<NotFound>(result.Result);
+    }
 }

--- a/src/Pulse.Tests/SessionRepositoryTests.cs
+++ b/src/Pulse.Tests/SessionRepositoryTests.cs
@@ -18,7 +18,7 @@ public class SessionRepositoryTests
         // Arrange
         var db = new LiteDatabase("Filename=:memory:");
         var collection = db.GetCollection<Session>("sessions");
-        
+
         var session = new Session
         {
             Id = Guid.NewGuid(),
@@ -30,7 +30,7 @@ public class SessionRepositoryTests
             UpdatedAt = DateTime.UtcNow
         };
         collection.Insert(session);
-        
+
         var repo = new SessionRepository(db);
 
         // Act
@@ -88,7 +88,7 @@ public class SessionRepositoryTests
         // Arrange
         var db = new LiteDatabase("Filename=:memory:");
         var collection = db.GetCollection<Session>("sessions");
-        
+
         var session = new Session
         {
             Id = Guid.NewGuid(),
@@ -100,7 +100,7 @@ public class SessionRepositoryTests
             UpdatedAt = DateTime.UtcNow
         };
         collection.Insert(session);
-        
+
         var repo = new SessionRepository(db);
 
         // Act

--- a/src/Pulse.Tests/Sessions/CreateSessionTests.cs
+++ b/src/Pulse.Tests/Sessions/CreateSessionTests.cs
@@ -1,7 +1,11 @@
 using Moq;
+using LiteDB;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Pulse.Common.Services;
+using Pulse.Shared.Models;
 using Pulse.Shared.Services;
-using Xunit;
+using Pulse.WebApi.Middleware;
 
 namespace Pulse.Tests.Sessions;
 
@@ -55,5 +59,103 @@ public class JoinCodeGeneratorTests
 
         Assert.Equal("FREE22", joinCode);
         generatorMock.Verify(g => g.Generate(), Times.Exactly(2));
+    }
+}
+
+public class GetSessionsByInstructorCodeEndpointTests
+{
+    [Fact]
+    public async Task GetSessionsValidInstructorCodeReturns200AndArray()
+    {
+        using var db = new LiteDatabase("Filename=:memory:");
+        var collection = db.GetCollection<Session>("sessions");
+        collection.Insert(new Session
+        {
+            Id = Guid.NewGuid(),
+            Title = "Session A",
+            InstructorCode = "INST001",
+            JoinCode = "ABC123",
+            Status = "Active",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        collection.Insert(new Session
+        {
+            Id = Guid.NewGuid(),
+            Title = "Session B",
+            InstructorCode = "OTHER",
+            JoinCode = "ZZZ999",
+            Status = "Active",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        var repo = new SessionRepository(db);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "INST001";
+
+        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
+
+        Assert.Equal(StatusCodes.Status200OK, statusResult.StatusCode);
+
+        var sessions = Assert.IsAssignableFrom<IEnumerable<Session>>(valueResult.Value);
+        var list = sessions.ToList();
+
+        Assert.Single(list);
+        Assert.Equal("INST001", list[0].InstructorCode);
+    }
+
+    [Fact]
+    public async Task GetSessionsMissingInstructorCodeReturns401()
+    {
+        using var db = new LiteDatabase("Filename=:memory:");
+        var repo = new SessionRepository(db);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var context = new DefaultHttpContext();
+
+        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, statusResult.StatusCode);
+        Assert.Equal("InstructorCode is required.", valueResult.Value?.GetType().GetProperty("error")?.GetValue(valueResult.Value)?.ToString());
+    }
+
+    [Fact]
+    public async Task GetSessionsInvalidInstructorCodeReturns403()
+    {
+        using var db = new LiteDatabase("Filename=:memory:");
+        var repo = new SessionRepository(db);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Security:InstructorCode"] = "INST001"
+            })
+            .Build();
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "WRONG";
+
+        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, statusResult.StatusCode);
+        Assert.Equal("InstructorCode is invalid.", valueResult.Value?.GetType().GetProperty("error")?.GetValue(valueResult.Value)?.ToString());
     }
 }

--- a/src/Pulse.Tests/Sessions/CreateSessionTests.cs
+++ b/src/Pulse.Tests/Sessions/CreateSessionTests.cs
@@ -1,10 +1,10 @@
 using Moq;
 using LiteDB;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Pulse.Common.Services;
 using Pulse.Shared.Models;
 using Pulse.Shared.Services;
+using Pulse.WebApi;
 using Pulse.WebApi.Middleware;
 
 namespace Pulse.Tests.Sessions;
@@ -91,17 +91,11 @@ public class GetSessionsByInstructorCodeEndpointTests
         });
 
         var repo = new SessionRepository(db);
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Security:InstructorCode"] = "INST001"
-            })
-            .Build();
 
         var context = new DefaultHttpContext();
-        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "INST001";
+        context.Items[InstructorCodeMiddleware.HeaderName] = "INST001";
 
-        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
+        var result = await SessionEndpointHandlers.GetSessions(context, repo);
         var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
         var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
 
@@ -115,47 +109,33 @@ public class GetSessionsByInstructorCodeEndpointTests
     }
 
     [Fact]
-    public async Task GetSessionsMissingInstructorCodeReturns401()
+    public async Task GetSessionsNoMatchingCodeReturnsEmptyArray()
     {
         using var db = new LiteDatabase("Filename=:memory:");
+        var collection = db.GetCollection<Session>("sessions");
+        collection.Insert(new Session
+        {
+            Id = Guid.NewGuid(),
+            Title = "Session A",
+            InstructorCode = "OTHER",
+            JoinCode = "ABC123",
+            Status = "Active",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
         var repo = new SessionRepository(db);
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Security:InstructorCode"] = "INST001"
-            })
-            .Build();
 
         var context = new DefaultHttpContext();
+        context.Items[InstructorCodeMiddleware.HeaderName] = "INST001";
 
-        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
+        var result = await SessionEndpointHandlers.GetSessions(context, repo);
         var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
         var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
 
-        Assert.Equal(StatusCodes.Status401Unauthorized, statusResult.StatusCode);
-        Assert.Equal("InstructorCode is required.", valueResult.Value?.GetType().GetProperty("error")?.GetValue(valueResult.Value)?.ToString());
-    }
+        Assert.Equal(StatusCodes.Status200OK, statusResult.StatusCode);
 
-    [Fact]
-    public async Task GetSessionsInvalidInstructorCodeReturns403()
-    {
-        using var db = new LiteDatabase("Filename=:memory:");
-        var repo = new SessionRepository(db);
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Security:InstructorCode"] = "INST001"
-            })
-            .Build();
-
-        var context = new DefaultHttpContext();
-        context.Request.Headers[InstructorCodeMiddleware.HeaderName] = "WRONG";
-
-        var result = await SessionEndpointHandlers.GetSessions(context.Request, repo, configuration);
-        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-        var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
-
-        Assert.Equal(StatusCodes.Status403Forbidden, statusResult.StatusCode);
-        Assert.Equal("InstructorCode is invalid.", valueResult.Value?.GetType().GetProperty("error")?.GetValue(valueResult.Value)?.ToString());
+        var sessions = Assert.IsAssignableFrom<IEnumerable<Session>>(valueResult.Value);
+        Assert.Empty(sessions);
     }
 }

--- a/src/Pulse.WebApi/Middleware/InstructorCodeMiddleware.cs
+++ b/src/Pulse.WebApi/Middleware/InstructorCodeMiddleware.cs
@@ -1,11 +1,50 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Pulse.WebApi.Middleware;
 
 public sealed class InstructorCodeMiddleware
 {
     public const string HeaderName = "InstructorCode";
+
+    private readonly RequestDelegate _next;
+    private readonly IConfiguration _configuration;
+
+    public InstructorCodeMiddleware(RequestDelegate next, IConfiguration configuration)
+    {
+        _next = next;
+        _configuration = configuration;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        if (!InstructorOnlyEndpointMatcher.IsInstructorOnly(context.Request))
+        {
+            await _next(context);
+            return;
+        }
+
+        var instructorCode = context.Request.Headers[HeaderName].ToString();
+        if (string.IsNullOrWhiteSpace(instructorCode))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsJsonAsync(new { error = "InstructorCode is required." });
+            return;
+        }
+
+        var configuredInstructorCode = _configuration["Security:InstructorCode"];
+        if (!IsInstructorCodeValid(instructorCode, configuredInstructorCode))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsJsonAsync(new { error = "InstructorCode is invalid." });
+            return;
+        }
+
+        await _next(context);
+    }
 
     public static bool IsInstructorCodeValid(string? instructorCode, string? configuredInstructorCode)
     {
@@ -17,5 +56,63 @@ public sealed class InstructorCodeMiddleware
         return CryptographicOperations.FixedTimeEquals(
             Encoding.UTF8.GetBytes(instructorCode),
             Encoding.UTF8.GetBytes(configuredInstructorCode));
+    }
+}
+
+public static class InstructorOnlyEndpointMatcher
+{
+    private static readonly Regex SessionIdRouteRegex = new("^/sessions/[^/]+$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex SessionResultsRouteRegex = new("^/sessions/[^/]+/results$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex SessionQrRouteRegex = new("^/sessions/[^/]+/(qr|qr-code)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex PublicStudentSessionRouteRegex = new("^/sessions/[^/]+/(join|responses)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public static bool IsInstructorOnly(HttpRequest request)
+    {
+        var method = request.Method;
+        var path = request.Path.Value?.TrimEnd('/') ?? string.Empty;
+        if (string.IsNullOrEmpty(path))
+        {
+            path = "/";
+        }
+
+        if (HttpMethods.IsGet(method) && path == "/")
+        {
+            return false;
+        }
+
+        if (HttpMethods.IsGet(method) && path.StartsWith("/questions", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (HttpMethods.IsPost(method) && PublicStudentSessionRouteRegex.IsMatch(path))
+        {
+            return false;
+        }
+
+        if (path.StartsWith("/questions", StringComparison.OrdinalIgnoreCase)
+            && (HttpMethods.IsPost(method) || HttpMethods.IsPut(method) || HttpMethods.IsDelete(method)))
+        {
+            return true;
+        }
+
+        if ((HttpMethods.IsPost(method) || HttpMethods.IsGet(method))
+            && path.Equals("/sessions", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if ((HttpMethods.IsPut(method) || HttpMethods.IsDelete(method))
+            && SessionIdRouteRegex.IsMatch(path))
+        {
+            return true;
+        }
+
+        if (HttpMethods.IsGet(method) && (SessionResultsRouteRegex.IsMatch(path) || SessionQrRouteRegex.IsMatch(path)))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Pulse.WebApi/Middleware/InstructorCodeMiddleware.cs
+++ b/src/Pulse.WebApi/Middleware/InstructorCodeMiddleware.cs
@@ -1,0 +1,21 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Pulse.WebApi.Middleware;
+
+public sealed class InstructorCodeMiddleware
+{
+    public const string HeaderName = "InstructorCode";
+
+    public static bool IsInstructorCodeValid(string? instructorCode, string? configuredInstructorCode)
+    {
+        if (string.IsNullOrWhiteSpace(instructorCode) || string.IsNullOrWhiteSpace(configuredInstructorCode))
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(instructorCode),
+            Encoding.UTF8.GetBytes(configuredInstructorCode));
+    }
+}

--- a/src/Pulse.WebApi/Middleware/InstructorCodeMiddleware.cs
+++ b/src/Pulse.WebApi/Middleware/InstructorCodeMiddleware.cs
@@ -43,6 +43,7 @@ public sealed class InstructorCodeMiddleware
             return;
         }
 
+        context.Items[HeaderName] = instructorCode;
         await _next(context);
     }
 
@@ -53,9 +54,9 @@ public sealed class InstructorCodeMiddleware
             return false;
         }
 
-        return CryptographicOperations.FixedTimeEquals(
-            Encoding.UTF8.GetBytes(instructorCode),
-            Encoding.UTF8.GetBytes(configuredInstructorCode));
+        var instructorCodeHash = SHA256.HashData(Encoding.UTF8.GetBytes(instructorCode));
+        var configuredHash = SHA256.HashData(Encoding.UTF8.GetBytes(configuredInstructorCode));
+        return CryptographicOperations.FixedTimeEquals(instructorCodeHash, configuredHash);
     }
 }
 

--- a/src/Pulse.WebApi/Program.cs
+++ b/src/Pulse.WebApi/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddOpenApi();
 var app = builder.Build();
 
 app.UseMiddleware<GlobalExceptionMiddleware>();
+app.UseMiddleware<InstructorCodeMiddleware>();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
@@ -52,6 +53,9 @@ app.MapPost("/questions", (QuestionRepository repo, Question q) =>
 
 app.MapPut("/questions/{id:guid}",
     QuestionEndpointHandlers.UpdateQuestion);
+
+app.MapDelete("/questions/{id:guid}",
+    QuestionEndpointHandlers.DeleteQuestion);
 
 app.MapGet("/sessions",
     (HttpRequest request, ISessionRepository repo, IConfiguration configuration) =>

--- a/src/Pulse.WebApi/Program.cs
+++ b/src/Pulse.WebApi/Program.cs
@@ -57,9 +57,7 @@ app.MapPut("/questions/{id:guid}",
 app.MapDelete("/questions/{id:guid}",
     QuestionEndpointHandlers.DeleteQuestion);
 
-app.MapGet("/sessions",
-    (HttpRequest request, ISessionRepository repo, IConfiguration configuration) =>
-        SessionEndpointHandlers.GetSessions(request, repo, configuration));
+app.MapGet("/sessions", SessionEndpointHandlers.GetSessions);
 
 app.MapDefaultEndpoints();
 
@@ -67,21 +65,11 @@ app.Run();
 
 public static class SessionEndpointHandlers
 {
-    public static async Task<IResult> GetSessions(HttpRequest request, ISessionRepository repo, IConfiguration configuration)
+    public static async Task<IResult> GetSessions(HttpContext context, ISessionRepository repo)
     {
-        var instructorCode = request.Headers[InstructorCodeMiddleware.HeaderName].ToString();
-
-        if (string.IsNullOrWhiteSpace(instructorCode))
-        {
-            return Results.Json(new { error = "InstructorCode is required." }, statusCode: StatusCodes.Status401Unauthorized);
-        }
-
-        var configuredInstructorCode = configuration["Security:InstructorCode"];
-        if (!InstructorCodeMiddleware.IsInstructorCodeValid(instructorCode, configuredInstructorCode))
-        {
-            return Results.Json(new { error = "InstructorCode is invalid." }, statusCode: StatusCodes.Status403Forbidden);
-        }
-
+        var instructorCode = context.Items[InstructorCodeMiddleware.HeaderName]?.ToString()
+            ?? throw new InvalidOperationException(
+                "InstructorCode was not set by InstructorCodeMiddleware. Ensure the middleware is registered.");
         var sessions = await repo.GetByInstructorCodeAsync(instructorCode);
         return Results.Ok(sessions);
     }

--- a/src/Pulse.WebApi/Program.cs
+++ b/src/Pulse.WebApi/Program.cs
@@ -3,8 +3,6 @@ using Pulse.WebApi.Middleware;
 using Pulse.Common.Services;
 using Pulse.WebApi;
 using Scalar.AspNetCore;
-using System.Security.Cryptography;
-using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -75,23 +73,12 @@ public static class SessionEndpointHandlers
         }
 
         var configuredInstructorCode = configuration["Security:InstructorCode"];
-        if (string.IsNullOrWhiteSpace(configuredInstructorCode) ||
-            !CryptographicOperations.FixedTimeEquals(
-                Encoding.UTF8.GetBytes(instructorCode),
-                Encoding.UTF8.GetBytes(configuredInstructorCode)))
+        if (!InstructorCodeMiddleware.IsInstructorCodeValid(instructorCode, configuredInstructorCode))
         {
             return Results.Json(new { error = "InstructorCode is invalid." }, statusCode: StatusCodes.Status403Forbidden);
         }
 
         var sessions = await repo.GetByInstructorCodeAsync(instructorCode);
         return Results.Ok(sessions);
-    }
-}
-
-namespace Pulse.WebApi.Middleware
-{
-    public static class InstructorCodeMiddleware
-    {
-        public const string HeaderName = "InstructorCode";
     }
 }

--- a/src/Pulse.WebApi/Program.cs
+++ b/src/Pulse.WebApi/Program.cs
@@ -3,6 +3,8 @@ using Pulse.WebApi.Middleware;
 using Pulse.Common.Services;
 using Pulse.WebApi;
 using Scalar.AspNetCore;
+using System.Security.Cryptography;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -53,6 +55,43 @@ app.MapPost("/questions", (QuestionRepository repo, Question q) =>
 app.MapPut("/questions/{id:guid}",
     QuestionEndpointHandlers.UpdateQuestion);
 
+app.MapGet("/sessions",
+    (HttpRequest request, ISessionRepository repo, IConfiguration configuration) =>
+        SessionEndpointHandlers.GetSessions(request, repo, configuration));
+
 app.MapDefaultEndpoints();
 
 app.Run();
+
+public static class SessionEndpointHandlers
+{
+    public static async Task<IResult> GetSessions(HttpRequest request, ISessionRepository repo, IConfiguration configuration)
+    {
+        var instructorCode = request.Headers[InstructorCodeMiddleware.HeaderName].ToString();
+
+        if (string.IsNullOrWhiteSpace(instructorCode))
+        {
+            return Results.Json(new { error = "InstructorCode is required." }, statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var configuredInstructorCode = configuration["Security:InstructorCode"];
+        if (string.IsNullOrWhiteSpace(configuredInstructorCode) ||
+            !CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(instructorCode),
+                Encoding.UTF8.GetBytes(configuredInstructorCode)))
+        {
+            return Results.Json(new { error = "InstructorCode is invalid." }, statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        var sessions = await repo.GetByInstructorCodeAsync(instructorCode);
+        return Results.Ok(sessions);
+    }
+}
+
+namespace Pulse.WebApi.Middleware
+{
+    public static class InstructorCodeMiddleware
+    {
+        public const string HeaderName = "InstructorCode";
+    }
+}

--- a/src/Pulse.WebApi/QuestionEndpointHandlers.cs
+++ b/src/Pulse.WebApi/QuestionEndpointHandlers.cs
@@ -47,8 +47,13 @@ public static class QuestionEndpointHandlers
         return TypedResults.Ok(existing);
     }
 
-    public static Results<NoContent, NotFound> DeleteQuestion(Guid id, QuestionRepository repo)
+    public static Results<NoContent, BadRequest<string>, NotFound> DeleteQuestion(Guid id, QuestionRepository repo)
     {
+        if (id == Guid.Empty)
+        {
+            return TypedResults.BadRequest("Question id is invalid.");
+        }
+
         var deleted = repo.Delete(id);
         if (!deleted)
         {

--- a/src/Pulse.WebApi/QuestionEndpointHandlers.cs
+++ b/src/Pulse.WebApi/QuestionEndpointHandlers.cs
@@ -46,6 +46,17 @@ public static class QuestionEndpointHandlers
 
         return TypedResults.Ok(existing);
     }
+
+    public static Results<NoContent, NotFound> DeleteQuestion(Guid id, QuestionRepository repo)
+    {
+        var deleted = repo.Delete(id);
+        if (!deleted)
+        {
+            return TypedResults.NotFound();
+        }
+
+        return TypedResults.NoContent();
+    }
 }
 
 public sealed class UpdateQuestionRequest

--- a/src/Pulse.WebApi/appsettings.Development.json
+++ b/src/Pulse.WebApi/appsettings.Development.json
@@ -5,5 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "Security": { "InstructorCode": "INST001" }
+  "Security": {}
 }

--- a/src/Pulse.WebApi/appsettings.Development.json
+++ b/src/Pulse.WebApi/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "Security": { "InstructorCode": "INST001" }
 }


### PR DESCRIPTION
## Description
Endpoint that returns all sessions belonging to the instructor identified by their `InstructorCode`.

The `InstructorCode` is passed as an HTTP request **header** (not a query parameter). Access control is enforced by `InstructorCodeMiddleware` before the endpoint handler is reached.

## Acceptance Criteria

- Returns 200 and an array of sessions when the `InstructorCode` is valid
- Returns 401 when the `InstructorCode` header is missing
- Returns 403 when the `InstructorCode` header is present but invalid/unrecognised

## Implementation checklist

- [x] Add/confirm endpoint handler for `GET /sessions` in Web API.
- [x] Extract and validate the `InstructorCode` from the `InstructorCode` request header via `InstructorCodeMiddleware`.
- [x] Return 401 when `InstructorCode` is missing.
- [x] Return 403 when `InstructorCode` is present but invalid/unrecognised.
- [x] Lookup all sessions associated with the valid `InstructorCode` from the repository.
- [x] Return 200 with the array of session models on success.
- [x] Return an empty array (not 404) if the instructor has no sessions.
- [x] Add/confirm unit tests for valid code, missing code, and invalid code scenarios.

## Definition of Done checklist

- [x] Endpoint implemented and reachable.
- [x] Returns 200 + array of sessions for a valid `InstructorCode`.
- [x] Returns 401 for a missing `InstructorCode`.
- [x] Returns 403 for an invalid/unrecognised `InstructorCode`.
- [x] Automated tests added/updated and passing.
- [x] `dotnet build` succeeds.
- [x] Linting passes (`dotnet format --verify-no-changes`).

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes

## Additional changes from review feedback

- **`InstructorCodeMiddleware`**: `IsInstructorCodeValid` now uses SHA256 hashing before `FixedTimeEquals` to eliminate both the length-mismatch exception and length-based timing side channel. Validated `InstructorCode` is stashed in `HttpContext.Items` for downstream handlers.
- **`GetSessions` handler**: Removed duplicate 401/403 auth logic (now solely enforced by middleware); handler reads the pre-validated code from `HttpContext.Items`.
- **`DeleteQuestion`**: Added `Guid.Empty` validation returning 400, consistent with `UpdateQuestion`.
- **`appsettings.Development.json`**: Removed committed `InstructorCode` secret value; configure via environment variables or user-secrets instead.
- **Tests**: Consolidated endpoint tests under `Sessions/CreateSessionTests.cs`; removed duplicate class from `GlobalExceptionMiddlewareTests.cs`; added explicit 401/403 middleware tests for `GET /sessions`.

<img width="395" height="80" alt="Screenshot 2026-04-02 at 9 33 28 PM" src="https://github.com/user-attachments/assets/a3a49f48-2d0a-46d6-bf32-cb60f034b623" />
<img width="357" height="79" alt="Screenshot 2026-04-02 at 9 34 22 PM" src="https://github.com/user-attachments/assets/80931dde-367d-49fe-91a0-c553e4ce36cf" />
<img width="342" height="77" alt="Screenshot 2026-04-02 at 9 35 00 PM" src="https://github.com/user-attachments/assets/9d0d3576-c2b8-4900-8e10-58cfcc0a3e8b" />
<img width="809" height="226" alt="Screenshot 2026-04-02 at 9 35 50 PM" src="https://github.com/user-attachments/assets/30f50d03-eff9-4ae4-9b8d-aa49bc9367cd" />
<img width="890" height="210" alt="Screenshot 2026-04-02 at 9 36 52 PM" src="https://github.com/user-attachments/assets/c94677b0-db6e-4823-a65d-ad782cc8c4db" />
<img width="970" height="168" alt="Screenshot 2026-04-02 at 9 37 29 PM" src="https://github.com/user-attachments/assets/7ceb2805-4d3d-4309-9b88-aea0160769a1" />
