### PR TITLE
"Implemented QuestionBankItem model and QuestionBankRepository (#43)"

### DIFF
--- a/src/Pulse.Shared/Models/QuestionBankItem.cs
+++ b/src/Pulse.Shared/Models/QuestionBankItem.cs
@@ -1,0 +1,14 @@
+using LiteDB;
+using Pulse.Domain.Entities;
+
+namespace Pulse.Shared.Models;
+
+public class QuestionBankItem
+{
+    [BsonField("Id")]
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Text { get; set; } = string.Empty;
+    public QuestionType Type { get; set; }
+    public List<string> Options { get; set; } = [];
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Pulse.Shared/Services/IQuestionBankRepository.cs
+++ b/src/Pulse.Shared/Services/IQuestionBankRepository.cs
@@ -1,0 +1,13 @@
+using Pulse.Shared.Models;
+
+namespace Pulse.Common.Services;
+
+public interface IQuestionBankRepository
+{
+    QuestionBankItem Insert(QuestionBankItem item);
+    IEnumerable<QuestionBankItem> GetAll();
+    QuestionBankItem? GetById(Guid id);
+    bool Update(QuestionBankItem item);
+    bool Delete(Guid id);
+    IEnumerable<QuestionBankItem> Search(string? text = null, int? type = null);
+}

--- a/src/Pulse.Shared/Services/QuestionBankRepository.cs
+++ b/src/Pulse.Shared/Services/QuestionBankRepository.cs
@@ -1,0 +1,43 @@
+using LiteDB;
+using Pulse.Shared.Models;
+
+namespace Pulse.Common.Services;
+
+public class QuestionBankRepository : IQuestionBankRepository
+{
+    private readonly ILiteCollection<QuestionBankItem> _col;
+
+    public QuestionBankRepository(LiteDatabase db)
+    {
+        _col = db.GetCollection<QuestionBankItem>("questionbank");
+        _col.EnsureIndex(x => x.Type);
+        _col.EnsureIndex(x => x.Text);
+    }
+
+    public QuestionBankItem Insert(QuestionBankItem item)
+    {
+        _col.Insert(item);
+        return item;
+    }
+
+    public IEnumerable<QuestionBankItem> GetAll() => _col.FindAll();
+
+    public QuestionBankItem? GetById(Guid id) => _col.FindById(id);
+
+    public bool Update(QuestionBankItem item) => _col.Update(item);
+
+    public bool Delete(Guid id) => _col.Delete(id);
+
+    public IEnumerable<QuestionBankItem> Search(string? text = null, int? type = null)
+    {
+        var all = _col.FindAll();
+
+        if (!string.IsNullOrWhiteSpace(text))
+            all = all.Where(x => x.Text.Contains(text, StringComparison.OrdinalIgnoreCase));
+
+        if (type is not null)
+            all = all.Where(x => (int)x.Type == type.Value);
+
+        return all;
+    }
+}

--- a/src/Pulse.Tests/QuestionBankRepositoryTests.cs
+++ b/src/Pulse.Tests/QuestionBankRepositoryTests.cs
@@ -1,0 +1,125 @@
+using LiteDB;
+using Pulse.Common.Services;
+using Pulse.Domain.Entities;
+using Pulse.Shared.Models;
+
+namespace Pulse.Tests.Tests;
+
+public class QuestionBankRepositoryTests
+{
+    private QuestionBankRepository CreateRepository()
+    {
+        var db = new LiteDatabase("Filename=:memory:");
+        return new QuestionBankRepository(db);
+    }
+
+    [Fact]
+    public void Insert_AndGetById_ReturnsItem()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        var item = new QuestionBankItem { Text = "What is 2+2?", Type = QuestionType.MultipleChoice, Options = ["4", "3"] };
+
+        // Act
+        var inserted = repo.Insert(item);
+        var result = repo.GetById(inserted.Id);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("What is 2+2?", result.Text);
+        Assert.Equal(inserted.Id, result.Id);
+    }
+
+    [Fact]
+    public void GetAll_ReturnsAllItems()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        repo.Insert(new QuestionBankItem { Text = "Question A", Type = QuestionType.MultipleChoice });
+        repo.Insert(new QuestionBankItem { Text = "Question B", Type = QuestionType.MultipleChoice });
+
+        // Act
+        var all = repo.GetAll().ToList();
+
+        // Assert
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public void GetById_WhenNotFound_ReturnsNull()
+    {
+        // Arrange
+        var repo = CreateRepository();
+
+        // Act
+        var result = repo.GetById(Guid.NewGuid());
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Update_ChangesText()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        var item = repo.Insert(new QuestionBankItem { Text = "Original", Type = QuestionType.MultipleChoice });
+
+        // Act
+        item.Text = "Updated";
+        var success = repo.Update(item);
+        var result = repo.GetById(item.Id);
+
+        // Assert
+        Assert.True(success);
+        Assert.Equal("Updated", result?.Text);
+    }
+
+    [Fact]
+    public void Delete_RemovesItem()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        var item = repo.Insert(new QuestionBankItem { Text = "To Delete", Type = QuestionType.MultipleChoice });
+
+        // Act
+        var deleted = repo.Delete(item.Id);
+        var result = repo.GetById(item.Id);
+
+        // Assert
+        Assert.True(deleted);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Search_ByText_ReturnsMatchingItems()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        repo.Insert(new QuestionBankItem { Text = "What is photosynthesis?", Type = QuestionType.MultipleChoice });
+        repo.Insert(new QuestionBankItem { Text = "What is gravity?", Type = QuestionType.MultipleChoice });
+        repo.Insert(new QuestionBankItem { Text = "Who wrote Hamlet?", Type = QuestionType.MultipleChoice });
+
+        // Act
+        var results = repo.Search(text: "What is").ToList();
+
+        // Assert
+        Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
+    public void Search_ByType_ReturnsMatchingItems()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        repo.Insert(new QuestionBankItem { Text = "MC Question", Type = QuestionType.MultipleChoice });
+        repo.Insert(new QuestionBankItem { Text = "TF Question", Type = QuestionType.LikertScale });
+
+        // Act
+        var results = repo.Search(type: (int)QuestionType.MultipleChoice).ToList();
+
+        // Assert
+        Assert.Single(results);
+        Assert.Equal("MC Question", results[0].Text);
+    }
+}

--- a/src/Pulse.WebApi/ServiceCollectionExtensions.cs
+++ b/src/Pulse.WebApi/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IJoinCodeGenerator, JoinCodeGenerator>();
         services.AddSingleton<ISessionRepository, SessionRepository>();
         services.AddSingleton<QuestionRepository>();
+        services.AddSingleton<IQuestionBankRepository, QuestionBankRepository>();
 
         return services;
     }


### PR DESCRIPTION
```
## Description
Implements the `QuestionBankItem` model and `QuestionBankRepository` for #43.

- Added `QuestionBankItem` model with `Id`, `Text`, `Type`, `Options`, and `CreatedAt` properties
- Added `IQuestionBankRepository` interface with full CRUD and search methods
- Implemented `QuestionBankRepository` using LiteDB with indexes on `Type` and `Text` for efficient searching
- Registered `IQuestionBankRepository` and `QuestionBankRepository` in DI

## Related Issues
Closes #43

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes

<img width="661" height="541" alt="Screenshot 2026-04-09 at 12 38 23 PM" src="https://github.com/user-attachments/assets/8ce971e9-9db8-40b3-8f78-145e62a9205c" />
<img width="654" height="288" alt="Screenshot 2026-04-09 at 12 45 14 PM" src="https://github.com/user-attachments/assets/ed240b84-8eb8-4cdc-b134-a272a4d7485d" />


