### PR TITLE
Implemented DeviceId UUID validation service (#19)

### DIFF
--- a/src/Pulse.Application/Services/DeviceIdValidationService.cs
+++ b/src/Pulse.Application/Services/DeviceIdValidationService.cs
@@ -1,0 +1,27 @@
+namespace Pulse.Application.Services;
+
+public sealed record DeviceIdValidationResult
+{
+    public bool IsValid { get; init; }
+    public string? ErrorMessage { get; init; }
+
+    public static DeviceIdValidationResult Success() =>
+        new() { IsValid = true };
+
+    public static DeviceIdValidationResult Failure(string errorMessage) =>
+        new() { IsValid = false, ErrorMessage = errorMessage };
+}
+
+public class DeviceIdValidationService
+{
+    public DeviceIdValidationResult ValidateDeviceId(string? deviceId)
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+            return DeviceIdValidationResult.Failure("DeviceId is required.");
+
+        if (!Guid.TryParse(deviceId, out _))
+            return DeviceIdValidationResult.Failure("DeviceId must be a valid UUID.");
+
+        return DeviceIdValidationResult.Success();
+    }
+}

--- a/src/Pulse.Tests/DeviceIdValidationServiceTests.cs
+++ b/src/Pulse.Tests/DeviceIdValidationServiceTests.cs
@@ -1,0 +1,48 @@
+using Pulse.Application.Services;
+
+namespace Pulse.Tests;
+
+public class DeviceIdValidationServiceTests
+{
+    private readonly DeviceIdValidationService _svc = new();
+
+    [Fact]
+    public void ValidateDeviceId_ValidUUID_ReturnsSuccess()
+    {
+        var result = _svc.ValidateDeviceId(Guid.NewGuid().ToString());
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateDeviceId_EmptyString_ReturnsFailure()
+    {
+        var result = _svc.ValidateDeviceId("");
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateDeviceId_Null_ReturnsFailure()
+    {
+        var result = _svc.ValidateDeviceId(null);
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateDeviceId_MalformedString_ReturnsFailure()
+    {
+        var result = _svc.ValidateDeviceId("not-a-uuid");
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateDeviceId_WhitespaceOnly_ReturnsFailure()
+    {
+        var result = _svc.ValidateDeviceId("   ");
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.ErrorMessage);
+    }
+}


### PR DESCRIPTION
## Description
Implements the `DeviceIdValidationService` for validating that device identifiers are properly formatted UUIDs before processing responses.

- Added `DeviceIdValidationService` in `src/Pulse.Application/Services/`
- Added `DeviceIdValidationResult` record with `IsValid`, `ErrorMessage`, `Success()`, and `Failure()` factory methods
- Validates that `deviceId` is non-null, non-empty, and a valid UUID format using `Guid.TryParse`
- Unit tests added covering: valid UUID, empty string, null, malformed string, and whitespace-only input — all passing

## Related Issues
Closes #19

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes

<img width="686" height="601" alt="Screenshot 2026-04-16 at 11 09 47 AM" src="https://github.com/user-attachments/assets/1af76b90-65b2-4eb3-b407-fae76141b50d" />
<img width="657" height="552" alt="Screenshot 2026-04-16 at 11 10 49 AM" src="https://github.com/user-attachments/assets/35784be6-8101-4cd2-a5ba-e0564a5ac0ce" />
