### PR TITLE
Implemented ResponseRepository with upsert and compound index (#17)

### DIFF
--- a/src/Pulse.Shared/Services/IResponseRepository.cs
+++ b/src/Pulse.Shared/Services/IResponseRepository.cs
@@ -1,0 +1,9 @@
+using Pulse.Shared.Models;
+
+namespace Pulse.Common.Services;
+
+public interface IResponseRepository
+{
+    Response Upsert(Response response);
+    IEnumerable<Response> GetByQuestionId(Guid questionId);
+}

--- a/src/Pulse.Shared/Services/ResponseRepository.cs
+++ b/src/Pulse.Shared/Services/ResponseRepository.cs
@@ -1,0 +1,37 @@
+using LiteDB;
+using Pulse.Shared.Models;
+
+namespace Pulse.Common.Services;
+
+public class ResponseRepository : IResponseRepository
+{
+    private readonly ILiteCollection<Response> _col;
+
+    public ResponseRepository(LiteDatabase db)
+    {
+        _col = db.GetCollection<Response>("responses");
+        _col.EnsureIndex("device_question", "$.DeviceId + $.QuestionId", unique: false);
+    }
+
+    public Response Upsert(Response response)
+    {
+        var existing = _col.FindOne(r =>
+            r.DeviceId == response.DeviceId &&
+            r.QuestionId == response.QuestionId);
+
+        if (existing is not null)
+        {
+            response.Id = existing.Id;
+            _col.Update(response);
+        }
+        else
+        {
+            _col.Insert(response);
+        }
+
+        return response;
+    }
+
+    public IEnumerable<Response> GetByQuestionId(Guid questionId) =>
+        _col.Find(r => r.QuestionId == questionId);
+}

--- a/src/Pulse.Tests/ResponseRepositoryTests.cs
+++ b/src/Pulse.Tests/ResponseRepositoryTests.cs
@@ -1,0 +1,97 @@
+using LiteDB;
+using Pulse.Common.Services;
+using Pulse.Shared.Models;
+
+namespace Pulse.Tests.Tests;
+
+public class ResponseRepositoryTests
+{
+    private ResponseRepository CreateRepository()
+    {
+        var db = new LiteDatabase("Filename=:memory:");
+        return new ResponseRepository(db);
+    }
+
+    [Fact]
+    public void Upsert_NewResponse_CreatesRecord()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        var response = new Response
+        {
+            QuestionId = Guid.NewGuid(),
+            SessionId = Guid.NewGuid(),
+            DeviceId = Guid.NewGuid().ToString(),
+            Value = "A"
+        };
+
+        // Act
+        var result = repo.Upsert(response);
+        var all = repo.GetByQuestionId(response.QuestionId).ToList();
+
+        // Assert
+        Assert.Single(all);
+        Assert.Equal("A", all[0].Value);
+    }
+
+    [Fact]
+    public void Upsert_SameDeviceAndQuestion_ReplacesValue()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        var questionId = Guid.NewGuid();
+        var deviceId = Guid.NewGuid().ToString();
+
+        var first = new Response { QuestionId = questionId, SessionId = Guid.NewGuid(), DeviceId = deviceId, Value = "A" };
+        var second = new Response { QuestionId = questionId, SessionId = Guid.NewGuid(), DeviceId = deviceId, Value = "B" };
+
+        // Act
+        repo.Upsert(first);
+        repo.Upsert(second);
+        var all = repo.GetByQuestionId(questionId).ToList();
+
+        // Assert
+        Assert.Single(all);
+        Assert.Equal("B", all[0].Value);
+    }
+
+    [Fact]
+    public void Upsert_DifferentDevice_CreatesNewRecord()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        var questionId = Guid.NewGuid();
+
+        var first = new Response { QuestionId = questionId, SessionId = Guid.NewGuid(), DeviceId = Guid.NewGuid().ToString(), Value = "A" };
+        var second = new Response { QuestionId = questionId, SessionId = Guid.NewGuid(), DeviceId = Guid.NewGuid().ToString(), Value = "B" };
+
+        // Act
+        repo.Upsert(first);
+        repo.Upsert(second);
+        var all = repo.GetByQuestionId(questionId).ToList();
+
+        // Assert
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public void Upsert_DifferentQuestion_CreatesNewRecord()
+    {
+        // Arrange
+        var repo = CreateRepository();
+        var deviceId = Guid.NewGuid().ToString();
+        var questionId1 = Guid.NewGuid();
+        var questionId2 = Guid.NewGuid();
+
+        var first = new Response { QuestionId = questionId1, SessionId = Guid.NewGuid(), DeviceId = deviceId, Value = "A" };
+        var second = new Response { QuestionId = questionId2, SessionId = Guid.NewGuid(), DeviceId = deviceId, Value = "B" };
+
+        // Act
+        repo.Upsert(first);
+        repo.Upsert(second);
+
+        // Assert
+        Assert.Single(repo.GetByQuestionId(questionId1).ToList());
+        Assert.Single(repo.GetByQuestionId(questionId2).ToList());
+    }
+}

--- a/src/Pulse.WebApi/ServiceCollectionExtensions.cs
+++ b/src/Pulse.WebApi/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<QuestionRepository>();
         services.AddSingleton<QuestionService>();
         services.AddSingleton<IQuestionBankRepository, QuestionBankRepository>();
+        services.AddSingleton<IResponseRepository, ResponseRepository>();
 
         return services;
     }


### PR DESCRIPTION
## Description
Implements `IResponseRepository` and `ResponseRepository` with upsert logic to ensure a single response per device/question pair.

- Added `IResponseRepository` interface with `Upsert` and `GetByQuestionId` methods
- Implemented `ResponseRepository` using LiteDB with a compound index on `DeviceId` + `QuestionId`
- Upsert replaces the existing response when the same device submits for the same question
- Upsert creates a new response for different device/question combinations
- Registered `IResponseRepository` and `ResponseRepository` as singletons in DI
- Unit tests added covering: new response creation, same device/question replacement, different device creates new record, different question creates new record — all passing

## Related Issues
Closes #17

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes

<img width="680" height="593" alt="Screenshot 2026-04-16 at 11 35 14 AM" src="https://github.com/user-attachments/assets/4f515f2d-0bc8-4a6c-9e29-4820ecde84c1" />
<img width="639" height="297" alt="Screenshot 2026-04-16 at 11 35 50 AM" src="https://github.com/user-attachments/assets/27fb60e2-fb10-4bdd-929a-9fa9159dcf64" />
