### PR TITLE
Implemented ResponseAggregationService with GetResponseCounts (#33)

### DIFF
--- a/src/Pulse.Application/Services/ResponseAggregationService.cs
+++ b/src/Pulse.Application/Services/ResponseAggregationService.cs
@@ -1,0 +1,43 @@
+using Pulse.Common.Services;
+
+namespace Pulse.Application.Services;
+
+public sealed record QuestionTally(string Option, int Count);
+
+public sealed record AggregationResult
+{
+    public bool IsValid { get; init; }
+    public string? ErrorMessage { get; init; }
+    public IReadOnlyList<QuestionTally> Tallies { get; init; } = [];
+
+    public static AggregationResult Success(IReadOnlyList<QuestionTally> tallies) =>
+        new() { IsValid = true, Tallies = tallies };
+
+    public static AggregationResult Failure(string errorMessage) =>
+        new() { IsValid = false, ErrorMessage = errorMessage };
+}
+
+public class ResponseAggregationService
+{
+    private readonly IResponseRepository _repo;
+
+    public ResponseAggregationService(IResponseRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public AggregationResult GetResponseCounts(Guid questionId)
+    {
+        if (questionId == Guid.Empty)
+            return AggregationResult.Failure("Question ID is invalid.");
+
+        var responses = _repo.GetByQuestionId(questionId).ToList();
+
+        var tallies = responses
+            .GroupBy(r => r.Value)
+            .Select(g => new QuestionTally(g.Key, g.Count()))
+            .ToList();
+
+        return AggregationResult.Success(tallies);
+    }
+}

--- a/src/Pulse.Tests/ResponseAggregationServiceTests.cs
+++ b/src/Pulse.Tests/ResponseAggregationServiceTests.cs
@@ -1,0 +1,59 @@
+using Moq;
+using Pulse.Application.Services;
+using Pulse.Common.Services;
+using Pulse.Shared.Models;
+
+namespace Pulse.Tests.Tests;
+
+public class ResponseAggregationServiceTests
+{
+    private Mock<IResponseRepository> BuildRepo(List<Response> responses)
+    {
+        var repo = new Mock<IResponseRepository>();
+        repo.Setup(r => r.GetByQuestionId(It.IsAny<Guid>()))
+            .Returns((Guid id) => responses.Where(r => r.QuestionId == id));
+        return repo;
+    }
+
+    [Fact]
+    public void GetResponseCounts_ValidQuestion_ReturnsCorrectCounts()
+    {
+        var questionId = Guid.NewGuid();
+        var responses = new List<Response>
+        {
+            new() { QuestionId = questionId, DeviceId = "d1", Value = "A" },
+            new() { QuestionId = questionId, DeviceId = "d2", Value = "A" },
+            new() { QuestionId = questionId, DeviceId = "d3", Value = "B" },
+        };
+        var svc = new ResponseAggregationService(BuildRepo(responses).Object);
+
+        var result = svc.GetResponseCounts(questionId);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(2, result.Tallies.First(t => t.Option == "A").Count);
+        Assert.Equal(1, result.Tallies.First(t => t.Option == "B").Count);
+    }
+
+    [Fact]
+    public void GetResponseCounts_NoResponses_ReturnsEmptyTallies()
+    {
+        var questionId = Guid.NewGuid();
+        var svc = new ResponseAggregationService(BuildRepo([]).Object);
+
+        var result = svc.GetResponseCounts(questionId);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Tallies);
+    }
+
+    [Fact]
+    public void GetResponseCounts_InvalidQuestionId_ReturnsFailure()
+    {
+        var svc = new ResponseAggregationService(BuildRepo([]).Object);
+
+        var result = svc.GetResponseCounts(Guid.Empty);
+
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.ErrorMessage);
+    }
+}


### PR DESCRIPTION
## Description
Implements the `ResponseAggregationService` with a `GetResponseCounts` method that computes response counts per option for a given question.

- Added `ResponseAggregationService` in `src/Pulse.Application/Services/`
- Added `AggregationResult` record with `IsValid`, `ErrorMessage`, `Tallies`, `Success()`, and `Failure()` factory methods
- Added `QuestionTally` record mapping each option to its response count
- Groups responses by value and returns counts per option
- Returns empty tallies for questions with no responses
- Returns failure for invalid question ID
- Unit tests added covering: correct counts, empty response set, and invalid question ID — all passing

## Related Issues
Closes #33

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes

<img width="661" height="274" alt="Screenshot 2026-04-17 at 12 21 29 PM" src="https://github.com/user-attachments/assets/5364d911-f88c-40e2-83b2-66be4eaf7635" />
<img width="698" height="600" alt="Screenshot 2026-04-17 at 12 20 26 PM" src="https://github.com/user-attachments/assets/7a46cc11-056b-481e-8f40-73dc031be728" />
