### PR TITLE
Add Sessions navigation link and implement Session List page with CRU…

### DIFF
--- a/src/Pulse.Tests/WebApp/SessionListPageTests.cs
+++ b/src/Pulse.Tests/WebApp/SessionListPageTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Bunit;
+using Pulse.Shared.Models;
+using Pulse.WebApp.Components.Pages;
+using Xunit;
+
+namespace Pulse.Tests.WebApp;
+
+#pragma warning disable CS0618
+public class SessionListPageTests : Bunit.TestContext
+{
+    private const string InstructorCode = "INST-123";
+
+    [Fact]
+    public void OnInitialized_LoadsSessions_AndRendersRows()
+    {
+        var sessionId = Guid.NewGuid();
+        var sessions = new List<Session>
+        {
+            new()
+            {
+                Id = sessionId,
+                Title = "Physics Quiz",
+                Status = "Draft",
+                JoinCode = "ABC123",
+                InstructorCode = InstructorCode
+            }
+        };
+
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/sessions")
+            {
+                return JsonResponse(HttpStatusCode.OK, sessions);
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, new { error = "Not found" });
+        });
+
+        Services.AddSingleton(new HttpClient(handler) { BaseAddress = new Uri("http://localhost") });
+
+        var cut = Render<SessionListPage>(parameters =>
+            parameters.Add(p => p.InstructorCode, InstructorCode));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Physics Quiz", cut.Markup);
+            Assert.Contains("Draft", cut.Markup);
+        });
+
+        var getRequest = Assert.Single(handler.Requests, r => r.Method == HttpMethod.Get);
+        Assert.Equal("/api/sessions", getRequest.Path);
+        Assert.Equal(InstructorCode, getRequest.InstructorCode);
+    }
+
+    [Theory]
+    [InlineData("Draft", "open", "POST")]
+    [InlineData("Open", "activate", "POST")]
+    [InlineData("Active", "close", "POST")]
+    [InlineData("Draft", "delete", "DELETE")]
+    public void ActionButton_CallsEndpoint_AndRefreshesList(string status, string action, string expectedMethod)
+    {
+        var sessionId = Guid.NewGuid();
+        var sessions = new List<Session>
+        {
+            new()
+            {
+                Id = sessionId,
+                Title = "Session A",
+                Status = status,
+                JoinCode = "JOINME",
+                InstructorCode = InstructorCode
+            }
+        };
+
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/sessions")
+            {
+                return JsonResponse(HttpStatusCode.OK, sessions);
+            }
+
+            var expectedPath = action == "delete"
+                ? $"/api/sessions/{sessionId}"
+                : $"/api/sessions/{sessionId}/{action}";
+
+            if (request.Method.Method == expectedMethod && request.RequestUri?.AbsolutePath == expectedPath)
+            {
+                return JsonResponse(HttpStatusCode.OK, new { ok = true });
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, new { error = "Not found" });
+        });
+
+        Services.AddSingleton(new HttpClient(handler) { BaseAddress = new Uri("http://localhost") });
+
+        var cut = Render<SessionListPage>(parameters =>
+            parameters.Add(p => p.InstructorCode, InstructorCode));
+
+        cut.WaitForAssertion(() => Assert.Contains("Session A", cut.Markup));
+
+        var selector = $"button[data-testid='{action}-{sessionId}']";
+        cut.Find(selector).Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var actionPath = action == "delete"
+                ? $"/api/sessions/{sessionId}"
+                : $"/api/sessions/{sessionId}/{action}";
+
+            Assert.Contains(handler.Requests, r =>
+                r.Method.Method == expectedMethod &&
+                r.Path == actionPath &&
+                r.InstructorCode == InstructorCode);
+
+            var getCount = handler.Requests.Count(r => r.Method == HttpMethod.Get && r.Path == "/api/sessions");
+            Assert.True(getCount >= 2, "Expected list refresh GET after action success.");
+        });
+    }
+
+    [Fact]
+    public void FailedAction_ShowsFriendlyErrorMessage()
+    {
+        var sessionId = Guid.NewGuid();
+        var sessions = new List<Session>
+        {
+            new()
+            {
+                Id = sessionId,
+                Title = "Session B",
+                Status = "Draft",
+                JoinCode = "JOINB",
+                InstructorCode = InstructorCode
+            }
+        };
+
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/sessions")
+            {
+                return JsonResponse(HttpStatusCode.OK, sessions);
+            }
+
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == $"/api/sessions/{sessionId}/open")
+            {
+                return JsonResponse(HttpStatusCode.InternalServerError, new { error = "server error" });
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, new { error = "Not found" });
+        });
+
+        Services.AddSingleton(new HttpClient(handler) { BaseAddress = new Uri("http://localhost") });
+
+        var cut = Render<SessionListPage>(parameters =>
+            parameters.Add(p => p.InstructorCode, InstructorCode));
+
+        cut.WaitForAssertion(() => Assert.Contains("Session B", cut.Markup));
+
+        cut.Find($"button[data-testid='open-{sessionId}']").Click();
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains("We could not open this session. Please try again.", cut.Markup));
+    }
+
+    private static HttpResponseMessage JsonResponse<T>(HttpStatusCode code, T body)
+    {
+        return new HttpResponseMessage(code)
+        {
+            Content = JsonContent.Create(body)
+        };
+    }
+
+    private sealed record CapturedRequest(HttpMethod Method, string Path, string? InstructorCode);
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        : HttpMessageHandler
+    {
+        public List<CapturedRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.TryGetValues("InstructorCode", out var values);
+            Requests.Add(new CapturedRequest(
+                request.Method,
+                request.RequestUri?.AbsolutePath ?? string.Empty,
+                values?.FirstOrDefault()));
+
+            return Task.FromResult(responder(request));
+        }
+    }
+}

--- a/src/Pulse.WebApp/Components/Layout/NavMenu.razor
+++ b/src/Pulse.WebApp/Components/Layout/NavMenu.razor
@@ -25,6 +25,12 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="sessions">
+                <span class="bi bi-card-list" aria-hidden="true"></span> Sessions
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/Pulse.WebApp/Components/Pages/SessionListPage.razor
+++ b/src/Pulse.WebApp/Components/Pages/SessionListPage.razor
@@ -1,0 +1,240 @@
+@page "/sessions"
+@page "/sessions/{InstructorCode}"
+@using System.Net
+@using System.Net.Http.Json
+@using Pulse.Shared.Models
+@inject HttpClient Http
+
+<PageTitle>Session List - Pulse</PageTitle>
+
+<h1>Session List</h1>
+
+<div class="mb-3">
+    <label for="instructor-code" class="form-label">Instructor Code</label>
+    <input id="instructor-code"
+           class="form-control"
+           @bind="InstructorCodeInput"
+           @bind:event="oninput"
+           placeholder="Enter your instructor code" />
+    <button class="btn btn-primary mt-2"
+            @onclick="LoadSessionsAsync"
+            disabled="@IsBusy"
+            data-testid="load-sessions-button">
+        Load Sessions
+    </button>
+</div>
+
+@if (IsLoading)
+{
+    <p>Loading sessions...</p>
+}
+else if (!string.IsNullOrWhiteSpace(ErrorMessage))
+{
+    <div class="alert alert-danger" role="alert">@ErrorMessage</div>
+}
+
+@if (!IsLoading && Sessions.Count > 0)
+{
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var session in Sessions)
+            {
+                <tr>
+                    <td>@session.Title</td>
+                    <td>@session.Status</td>
+                    <td>
+                        @if (CanOpen(session.Status))
+                        {
+                            <button class="btn btn-outline-primary btn-sm me-1"
+                                    @onclick="() => OpenSessionAsync(session.Id)"
+                                    disabled="@IsBusy"
+                                    data-testid="@($"open-{session.Id}")">
+                                Open
+                            </button>
+                        }
+                        @if (CanActivate(session.Status))
+                        {
+                            <button class="btn btn-outline-success btn-sm me-1"
+                                    @onclick="() => ActivateSessionAsync(session.Id)"
+                                    disabled="@IsBusy"
+                                    data-testid="@($"activate-{session.Id}")">
+                                Activate
+                            </button>
+                        }
+                        @if (CanClose(session.Status))
+                        {
+                            <button class="btn btn-outline-warning btn-sm me-1"
+                                    @onclick="() => CloseSessionAsync(session.Id)"
+                                    disabled="@IsBusy"
+                                    data-testid="@($"close-{session.Id}")">
+                                Close
+                            </button>
+                        }
+                        <button class="btn btn-outline-danger btn-sm"
+                                @onclick="() => DeleteSessionAsync(session.Id)"
+                                disabled="@IsBusy"
+                                data-testid="@($"delete-{session.Id}")">
+                            Delete
+                        </button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    [Parameter] public string? InstructorCode { get; set; }
+
+    private readonly List<Session> Sessions = [];
+    private string InstructorCodeInput = string.Empty;
+    private string? ErrorMessage;
+    private bool IsLoading;
+    private bool IsActionInProgress;
+
+    private bool IsBusy => IsLoading || IsActionInProgress;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(InstructorCode))
+        {
+            InstructorCodeInput = InstructorCode;
+        }
+
+        await LoadSessionsAsync();
+    }
+
+    private async Task LoadSessionsAsync()
+    {
+        IsLoading = true;
+        ErrorMessage = null;
+
+        try
+        {
+            using var response = await SendGetSessionsRequestAsync("/api/sessions");
+
+            if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed)
+            {
+                using var fallbackResponse = await SendGetSessionsRequestAsync("/sessions");
+                await HandleListResponseAsync(fallbackResponse);
+            }
+            else
+            {
+                await HandleListResponseAsync(response);
+            }
+        }
+        catch
+        {
+            Sessions.Clear();
+            ErrorMessage = "We could not load sessions right now. Please try again.";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private Task OpenSessionAsync(Guid sessionId) =>
+        InvokeActionAsync(HttpMethod.Post, $"/api/sessions/{sessionId}/open", "open");
+
+    private Task ActivateSessionAsync(Guid sessionId) =>
+        InvokeActionAsync(HttpMethod.Post, $"/api/sessions/{sessionId}/activate", "activate");
+
+    private Task CloseSessionAsync(Guid sessionId) =>
+        InvokeActionAsync(HttpMethod.Post, $"/api/sessions/{sessionId}/close", "close");
+
+    private Task DeleteSessionAsync(Guid sessionId) =>
+        InvokeActionAsync(HttpMethod.Delete, $"/api/sessions/{sessionId}", "delete");
+
+    private async Task InvokeActionAsync(HttpMethod method, string url, string actionName)
+    {
+        IsActionInProgress = true;
+        ErrorMessage = null;
+
+        try
+        {
+            using var request = new HttpRequestMessage(method, url);
+            AddInstructorCodeHeader(request);
+            using var response = await Http.SendAsync(request);
+
+            if (response.IsSuccessStatusCode)
+            {
+                await LoadSessionsAsync();
+            }
+            else
+            {
+                ErrorMessage = $"We could not {actionName} this session. Please try again.";
+            }
+        }
+        catch
+        {
+            ErrorMessage = $"We could not {actionName} this session. Please try again.";
+        }
+        finally
+        {
+            IsActionInProgress = false;
+        }
+    }
+
+    private async Task HandleListResponseAsync(HttpResponseMessage response)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            var sessions = await response.Content.ReadFromJsonAsync<List<Session>>() ?? [];
+            Sessions.Clear();
+            Sessions.AddRange(sessions);
+            return;
+        }
+
+        Sessions.Clear();
+        ErrorMessage = GetListErrorMessage(response.StatusCode);
+    }
+
+    private async Task<HttpResponseMessage> SendGetSessionsRequestAsync(string path)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, path);
+        AddInstructorCodeHeader(request);
+        return await Http.SendAsync(request);
+    }
+
+    private void AddInstructorCodeHeader(HttpRequestMessage request)
+    {
+        if (!string.IsNullOrWhiteSpace(InstructorCodeInput))
+        {
+            request.Headers.TryAddWithoutValidation("InstructorCode", InstructorCodeInput.Trim());
+        }
+    }
+
+    private static string GetListErrorMessage(HttpStatusCode statusCode)
+    {
+        return statusCode switch
+        {
+            HttpStatusCode.Unauthorized => "Please enter your instructor code to view sessions.",
+            HttpStatusCode.Forbidden => "Your instructor code is invalid. Please try again.",
+            _ => "We could not load sessions right now. Please try again."
+        };
+    }
+
+    private static bool CanOpen(string? status) =>
+        NormalizeStatus(status) == "draft";
+
+    private static bool CanActivate(string? status) =>
+        NormalizeStatus(status) == "open";
+
+    private static bool CanClose(string? status)
+    {
+        var normalized = NormalizeStatus(status);
+        return normalized is "open" or "active";
+    }
+
+    private static string NormalizeStatus(string? status) =>
+        status?.Trim().ToLowerInvariant() ?? string.Empty;
+}
+


### PR DESCRIPTION
## Instructor session list page component

## Description

Added sessions page routes: /sessions and /sessions/{InstructorCode}.
Loads sessions on init and displays title/status in a table.
Wired actions: Open, Activate, Close, Delete to their API endpoints.
Refreshes list after successful actions.
Disables buttons during requests to prevent duplicate calls.
Shows friendly error messages on failed load/action.
Sends InstructorCode header from route/input.
Handles route mismatch by falling back from /api/sessions to /sessions (404/405).
Added bUnit tests for load success, action calls/refresh, and failure messaging.
Verified with passing targeted tests and successful solution

## Related Issues

Closes [#29](https://github.com/ECU-Pirate-Forge/pulse-2.0/issues/29)

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes

<img width="1450" height="660" alt="Screenshot 2026-04-22 021218" src="https://github.com/user-attachments/assets/72cbfb38-d925-4937-b560-f48e8bd2df7b" />
<img width="2524" height="1417" alt="Screenshot 2026-04-22 023913" src="https://github.com/user-attachments/assets/6e00ae9b-2dc1-4722-bb2e-ffb98a9b919b" />
